### PR TITLE
Set options = "HUGE"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: uscongress
 Type: Package
 Title: Fetch United States Congressional Records (1995-Present)
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: person("Steph", "Buongiorno",
                   email = "steph.buon@proton.me",
                   role = c("aut", "cre"))

--- a/R/zzz_helpers.R
+++ b/R/zzz_helpers.R
@@ -236,7 +236,7 @@ get_htm_content <- function(API_KEY, BASE_API_URL, package_id, granule_id) {
 #' @importFrom stringr str_replace_all
 #' @importFrom stringr str_squish
 process_speech <- function(API_KEY, record_url, record_date, record_title, htm_content) {
-  page <- read_html(htm_content)
+  page <- read_html(htm_content, options = "HUGE")
   pre_node <- html_node(page, "pre")
 
   if (is.null(pre_node)) {


### PR DESCRIPTION
The function errors with a file "CREC-1995-12-13 Granule: CREC-1995-12-13-pt1-PgH14375-4".

```
dat <- get_congressional_records(KEY, max_results = NULL, congress_session = 104)

Collected 14280 speeches. Package: CREC-1995-12-13 Granule: CREC-1995-12-13-pt1-PgH14375-4
Error in read_xml.raw(charToRaw(enc2utf8(x)), "UTF-8", ..., as_html = as_html,  : 
  Excessive depth in document: 256 use XML_PARSE_HUGE option [1]
Calls: .rs.sourceWithProgress ... get_congressional_records -> process_speech -> read_html -> read_html.default
In addition: There were 15 warnings (use warnings() to see them)
```

So I set `options = "HUGE"` as suggest in the error message. Then, it runs without problems.
```
Collected 26368 speeches. Package: CREC-1995-01-04 Granule: CREC-1995-01-04-pt3-PgS421
Collected 26369 speeches. Package: CREC-1995-01-04 Granule: CREC-1995-01-04-pt3-PgS423
Collected 26370 speeches. Package: CREC-1995-01-04 Granule: CREC-1995-01-04-pt3-PgS423-2
Scraping complete. Total speeches: 26370
```